### PR TITLE
Disables automated terraform apply and destroy validation

### DIFF
--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -39,7 +39,9 @@ jobs:
           cd /tmp/workspace
           terraform init
           terraform plan
-
+        env:
+          TF_VAR_ibmcloud_api_key: ${{ secrets.IBMCLOUD_API_KEY }}
+          IBMCLOUD_API_KEY: ${{ secrets.IBMCLOUD_API_KEY }}
   release:
     #    if: ${{ github.event_name == 'push' }}
     needs: verify

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -33,7 +33,9 @@ jobs:
       # Just do a terraform init to validate the basic structure of the module
       - name: Terraform init
         run: |
-          cd test/stages
+          mkdir ./workspace
+          cd ./workspace
+          cp ../test/stages/* .
           terraform init
 
   release:

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -35,6 +35,7 @@ jobs:
         run: |
           mkdir /tmp/workspace
           cp ./test/stages/* /tmp/workspace
+          ln -s ${PWD} /tmp/workspace/module
           cd /tmp/workspace
           terraform init
 

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -38,6 +38,7 @@ jobs:
           ln -s ${PWD} /tmp/workspace/module
           cd /tmp/workspace
           terraform init
+          terraform plan
 
   release:
     #    if: ${{ github.event_name == 'push' }}

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -29,23 +29,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v1
 
-      - name: Verify deploy on ${{ matrix.platform }}
-        uses: ibm-garage-cloud/action-module-verify-deploy@main
-        with:
-          clusterId: ${{ matrix.platform }}
-          validateDeployScript: .github/scripts/validate-deploy.sh
-        env:
-          TF_VAR_ibmcloud_api_key: ${{ secrets.IBMCLOUD_API_KEY }}
-          IBMCLOUD_API_KEY: ${{ secrets.IBMCLOUD_API_KEY }}
-
-      - name: Verify destroy on ${{ matrix.platform }}
-        uses: ibm-garage-cloud/action-module-verify-destroy@main
-        if: ${{ always() }}
-        with:
-          clusterId: ${{ matrix.platform }}
-        env:
-          TF_VAR_ibmcloud_api_key: ${{ secrets.IBMCLOUD_API_KEY }}
-          IBMCLOUD_API_KEY: ${{ secrets.IBMCLOUD_API_KEY }}
+      # Because of the cost of HPCS, we won't automate the testing of terraform apply and terraform destroy
+      # Just do a terraform init to validate the basic structure of the module
+      - name: Terraform init
+        run: |
+          cd test/stages
+          terraform init
 
   release:
     #    if: ${{ github.event_name == 'push' }}

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -33,9 +33,9 @@ jobs:
       # Just do a terraform init to validate the basic structure of the module
       - name: Terraform init
         run: |
-          mkdir ./workspace
-          cd ./workspace
-          cp ../test/stages/* .
+          mkdir /tmp/workspace
+          cp ./test/stages/* /tmp/workspace
+          cd /tmp/workspace
           terraform init
 
   release:

--- a/test/stages/stage1-resource-group.tf
+++ b/test/stages/stage1-resource-group.tf
@@ -2,5 +2,5 @@ module "resource_group" {
   source = "github.com/cloud-native-toolkit/terraform-ibm-resource-group.git"
 
   resource_group_name = var.resource_group_name
-  provision           = false
+  provision           = true
 }

--- a/test/stages/variables.tf
+++ b/test/stages/variables.tf
@@ -3,6 +3,7 @@
 variable "resource_group_name" {
   type        = string
   description = "Existing resource group where the IKS cluster will be provisioned."
+  default     = "test"
 }
 
 variable "ibmcloud_api_key" {
@@ -13,38 +14,11 @@ variable "ibmcloud_api_key" {
 variable "region" {
   type        = string
   description = "Region for VLANs defined in private_vlan_number and public_vlan_number."
-}
-
-variable "namespace" {
-  type        = string
-  description = "Namespace for tools"
-}
-
-variable "cluster_name" {
-  type        = string
-  description = "The name of the cluster"
-  default     = ""
-}
-
-variable "cluster_type" {
-  type        = string
-  description = "The type of cluster that should be created (openshift or kubernetes)"
-}
-
-variable "cluster_exists" {
-  type        = string
-  description = "Flag indicating if the cluster already exists (true or false)"
-  default     = "true"
+  default     = "us-east"
 }
 
 variable "name_prefix" {
   type        = string
   description = "Prefix name that should be used for the cluster and services. If not provided then resource_group_name will be used"
-  default     = "garage-devops"
-}
-
-variable "vpc_cluster" {
-  type        = bool
-  description = "Flag indicating that this is a vpc cluster"
-  default     = false
+  default     = "cloud-native-test"
 }


### PR DESCRIPTION
Due to the cost of this service, it is not feasible to provision and destroy an instance of the service each time a PR is created or a change is pushed to main.

We might want to further update the automated process by requiring the release to be manually published so we could do some form of manual testing prior to releasing.

Signed-off-by: Sean Sundberg <seansund@us.ibm.com>